### PR TITLE
Refactors structure set handling

### DIFF
--- a/common/src/main/java/dev/ftb/mods/ftbteambases/data/definition/StructureSetProvider.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/data/definition/StructureSetProvider.java
@@ -1,8 +1,11 @@
 package dev.ftb.mods.ftbteambases.data.definition;
 
+import dev.ftb.mods.ftbteambases.FTBTeamBases;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
+import net.minecraft.core.HolderSet;
 import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.levelgen.structure.StructureSet;
@@ -15,11 +18,35 @@ import java.util.stream.Stream;
 public interface StructureSetProvider {
     List<ResourceLocation> structureSetIds();
 
-    static Stream<Holder<StructureSet>> getStructureSets(HolderLookup<StructureSet> holderLookup, StructureSetProvider provider) {
+    static Stream<Holder<StructureSet>> getStructureSets(HolderLookup.RegistryLookup<StructureSet> holderLookup, StructureSetProvider provider) {
         List<Holder<StructureSet>> res = new ArrayList<>();
-        provider.structureSetIds().stream()
-                .map(id -> holderLookup.getOrThrow(TagKey.create(Registries.STRUCTURE_SET, id)))
-                .forEach(l -> l.forEach(res::add));
+
+        for (ResourceLocation id : provider.structureSetIds()) {
+            if (id.getPath().startsWith("#")) {
+                ResourceLocation tagId = ResourceLocation.tryParse(id.toString().substring(1));
+                if (tagId == null) {
+                    FTBTeamBases.LOGGER.warn("Invalid structure set tag format: {}", id);
+                    continue;
+                }
+
+                TagKey<StructureSet> tag = TagKey.create(Registries.STRUCTURE_SET, tagId);
+                try {
+                    HolderSet.Named<StructureSet> set = holderLookup.get(tag).orElseThrow();
+                    set.forEach(res::add);
+                } catch (Exception e) {
+                    FTBTeamBases.LOGGER.warn("Could not resolve structure set tag: {}", tagId, e);
+                }
+            } else {
+                try {
+                    Holder<StructureSet> holder = holderLookup.get(ResourceKey.create(Registries.STRUCTURE_SET, id)).orElseThrow();
+                    res.add(holder);
+                } catch (Exception e) {
+                    FTBTeamBases.LOGGER.warn("Could not resolve structure set ID: {}", id, e);
+                }
+            }
+        }
+
         return res.stream();
     }
+
 }

--- a/common/src/main/java/dev/ftb/mods/ftbteambases/util/DimensionUtils.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/util/DimensionUtils.java
@@ -14,13 +14,11 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.Holder;
 import net.minecraft.core.HolderLookup;
 import net.minecraft.core.Vec3i;
-import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.server.level.TicketType;
-import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
@@ -96,20 +94,27 @@ public class DimensionUtils {
         serverPlayer.inventoryMenu.slotsChanged(serverPlayer.getInventory());
     }
 
-    @NotNull
-    public static Stream<Holder<StructureSet>> possibleStructures(HolderLookup<StructureSet> holderLookup, ResourceLocation baseTemplateId) {
+    public static Stream<Holder<StructureSet>> possibleStructures(HolderLookup.RegistryLookup<StructureSet> holderLookup, ResourceLocation baseTemplateId) {
         return BaseDefinitionManager.getServerInstance().getBaseDefinition(baseTemplateId)
                 .map(baseTemplate -> getHolderStream(holderLookup, baseTemplate))
                 .orElse(Stream.of());
     }
 
-    private static @NotNull Stream<Holder<StructureSet>> getHolderStream(HolderLookup<StructureSet> holderLookup, BaseDefinition baseTemplate) {
-        return baseTemplate.constructionType().prebuilt().map(prebuilt ->
-                StructureSetProvider.getStructureSets(holderLookup, prebuilt)
-        ).orElse(baseTemplate.constructionType().pregen().map(pregen ->
-                StructureSetProvider.getStructureSets(holderLookup, pregen)
-        ).orElse(Stream.empty()));
+
+    @NotNull
+    private static Stream<Holder<StructureSet>> getHolderStream(HolderLookup.RegistryLookup<StructureSet> holderLookup, BaseDefinition baseTemplate) {
+        var construction = baseTemplate.constructionType();
+
+        if (construction.prebuilt().isPresent()) {
+            return StructureSetProvider.getStructureSets(holderLookup, construction.prebuilt().get());
+        } else if (construction.pregen().isPresent()) {
+            return StructureSetProvider.getStructureSets(holderLookup, construction.pregen().get());
+        } else {
+            return Stream.empty();
+        }
     }
+
+
 
     public static boolean teleport(ServerPlayer player, ResourceKey<Level> key, @Nullable BlockPos destPos) {
         return teleport(player, key, destPos, player.getYRot());

--- a/common/src/main/java/dev/ftb/mods/ftbteambases/util/DimensionUtils.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/util/DimensionUtils.java
@@ -94,11 +94,21 @@ public class DimensionUtils {
         serverPlayer.inventoryMenu.slotsChanged(serverPlayer.getInventory());
     }
 
-    public static Stream<Holder<StructureSet>> possibleStructures(HolderLookup.RegistryLookup<StructureSet> holderLookup, ResourceLocation baseTemplateId) {
-        return BaseDefinitionManager.getServerInstance().getBaseDefinition(baseTemplateId)
-                .map(baseTemplate -> getHolderStream(holderLookup, baseTemplate))
-                .orElse(Stream.of());
+    public static Stream<Holder<StructureSet>> possibleStructures(HolderLookup<StructureSet> holderLookup, ResourceLocation baseTemplateId) {
+        if (!(holderLookup instanceof HolderLookup.RegistryLookup<StructureSet> structureSetLookup)) {
+            FTBTeamBases.LOGGER.warn("Invalid holder lookup type for StructureSet");
+            return Stream.empty();
+        }
+
+        Optional<BaseDefinition> baseDefinitionOpt = BaseDefinitionManager.getServerInstance().getBaseDefinition(baseTemplateId);
+        if (baseDefinitionOpt.isEmpty()) {
+            return Stream.empty();
+        }
+
+        BaseDefinition base = baseDefinitionOpt.get();
+        return getHolderStream(structureSetLookup, base);
     }
+
 
     @NotNull
     private static Stream<Holder<StructureSet>> getHolderStream(HolderLookup.RegistryLookup<StructureSet> holderLookup, BaseDefinition baseTemplate) {

--- a/common/src/main/java/dev/ftb/mods/ftbteambases/util/DimensionUtils.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/util/DimensionUtils.java
@@ -100,7 +100,6 @@ public class DimensionUtils {
                 .orElse(Stream.of());
     }
 
-
     @NotNull
     private static Stream<Holder<StructureSet>> getHolderStream(HolderLookup.RegistryLookup<StructureSet> holderLookup, BaseDefinition baseTemplate) {
         var construction = baseTemplate.constructionType();
@@ -113,8 +112,6 @@ public class DimensionUtils {
             return Stream.empty();
         }
     }
-
-
 
     public static boolean teleport(ServerPlayer player, ResourceKey<Level> key, @Nullable BlockPos destPos) {
         return teleport(player, key, destPos, player.getYRot());
@@ -138,7 +135,7 @@ public class DimensionUtils {
                         vec = vec.add(new Vec3(respawnPosition.getX(), respawnPosition.getY(), respawnPosition.getZ()));
                     } else {
                         BlockPos levelSharedSpawn = BaseInstanceManager.get(player.server).getBaseForPlayer(player)
-                                        .map(LiveBaseDetails::spawnPos).orElse(BlockPos.ZERO);
+                                .map(LiveBaseDetails::spawnPos).orElse(BlockPos.ZERO);
                         vec = vec.add(new Vec3(levelSharedSpawn.getX(), levelSharedSpawn.getY(), levelSharedSpawn.getZ()));
                     }
                 } else {

--- a/common/src/main/java/dev/ftb/mods/ftbteambases/worldgen/chunkgen/CustomChunkGenerator.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/worldgen/chunkgen/CustomChunkGenerator.java
@@ -1,14 +1,12 @@
 package dev.ftb.mods.ftbteambases.worldgen.chunkgen;
 
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.ftb.mods.ftbteambases.FTBTeamBases;
 import dev.ftb.mods.ftbteambases.config.ServerConfig;
 import dev.ftb.mods.ftbteambases.mixin.ChunkGeneratorAccess;
 import dev.ftb.mods.ftbteambases.data.definition.BaseDefinitionProvider;
-import dev.ftb.mods.ftbteambases.util.DimensionUtils;
 import net.minecraft.core.*;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.resources.ResourceKey;
@@ -22,7 +20,6 @@ import net.minecraft.world.level.levelgen.RandomState;
 import net.minecraft.world.level.levelgen.structure.StructureSet;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Basically the vanilla NoiseBasedChunkGenerator, with an optional initial start structure.  Can be configured to use
@@ -80,9 +77,15 @@ public class CustomChunkGenerator extends NoiseBasedChunkGenerator implements Ba
 
     @Override
     public ChunkGeneratorStructureState createState(HolderLookup<StructureSet> holderLookup, RandomState randomState, long seed) {
-        return ChunkGeneratorStructureState.createForFlat(randomState, seed, this.biomeSource,
-                DimensionUtils.possibleStructures(holderLookup, baseTemplateId));
+        return ChunkGeneratorStructureState.createForNormal(
+                randomState,
+                seed,
+                this.biomeSource,
+                holderLookup
+        );
     }
+
+
 
     @Override
     protected MapCodec<? extends ChunkGenerator> codec() {

--- a/common/src/main/java/dev/ftb/mods/ftbteambases/worldgen/chunkgen/VoidChunkGenerator.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/worldgen/chunkgen/VoidChunkGenerator.java
@@ -73,12 +73,10 @@ public class VoidChunkGenerator extends NoiseBasedChunkGenerator implements Base
                 randomState,
                 seed,
                 this.biomeSource,
-                DimensionUtils.possibleStructures(
-                        (HolderLookup.RegistryLookup<StructureSet>) holderLookup,
-                        baseDefinitionId
-                )
+                DimensionUtils.possibleStructures(holderLookup, baseDefinitionId)
         );
     }
+
 
     @Override
     protected MapCodec<? extends ChunkGenerator> codec() {

--- a/common/src/main/java/dev/ftb/mods/ftbteambases/worldgen/chunkgen/VoidChunkGenerator.java
+++ b/common/src/main/java/dev/ftb/mods/ftbteambases/worldgen/chunkgen/VoidChunkGenerator.java
@@ -1,6 +1,5 @@
 package dev.ftb.mods.ftbteambases.worldgen.chunkgen;
 
-import com.mojang.serialization.Codec;
 import com.mojang.serialization.MapCodec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import dev.ftb.mods.ftbteambases.FTBTeamBases;
@@ -29,7 +28,6 @@ import net.minecraft.world.level.levelgen.structure.StructureSet;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Executor;
 
 /**
  * Basically the vanilla NoiseBasedChunkGenerator, with biome distribution but no actual blocks
@@ -71,8 +69,15 @@ public class VoidChunkGenerator extends NoiseBasedChunkGenerator implements Base
 
     @Override
     public ChunkGeneratorStructureState createState(HolderLookup<StructureSet> holderLookup, RandomState randomState, long seed) {
-        return ChunkGeneratorStructureState.createForFlat(randomState, seed, this.biomeSource,
-                DimensionUtils.possibleStructures(holderLookup, baseDefinitionId));
+        return ChunkGeneratorStructureState.createForFlat(
+                randomState,
+                seed,
+                this.biomeSource,
+                DimensionUtils.possibleStructures(
+                        (HolderLookup.RegistryLookup<StructureSet>) holderLookup,
+                        baseDefinitionId
+                )
+        );
     }
 
     @Override


### PR DESCRIPTION
Updates how structure sets are retrieved and handled, allowing for both direct IDs and tag-based lookups. This change (hopefully) ensures proper loading of structure sets whether they are referenced directly or through tags. Additionally this adjusts ChunkGeneratorStructureState creation for custom and void chunk generators to use correct method for structure set retrieval.

Fixes potential issues with structure set resolution.