### PR TITLE
Ensures the chunk is loaded before getting surface height

### DIFF
--- a/src/main/java/dev/ftb/mods/ftbteambases/data/construction/workers/AbstractStructureWorker.java
+++ b/src/main/java/dev/ftb/mods/ftbteambases/data/construction/workers/AbstractStructureWorker.java
@@ -77,10 +77,11 @@ public abstract class AbstractStructureWorker implements ConstructionWorker {
     protected final BlockPos getPlacementOrigin(ServerLevel level, XZ xz, Optional<Integer> yPos) {
         int x = xz.x();
         int z = xz.z();
-        if (yPos.isPresent()) {
-            return new BlockPos(x, yPos.get(), z);
-        }
-        level.getChunk(x >> 4, z >> 4);
-        return new BlockPos(x, level.getHeight(Heightmap.Types.WORLD_SURFACE, x, z), z);
+        return yPos
+                .map(y -> new BlockPos(x, y, z))
+                .orElseGet(() -> {
+                    level.getChunk(x >> 4, z >> 4);
+                    return new BlockPos(x, level.getHeight(Heightmap.Types.WORLD_SURFACE, x, z), z);
+                });
     }
 }

--- a/src/main/java/dev/ftb/mods/ftbteambases/data/construction/workers/AbstractStructureWorker.java
+++ b/src/main/java/dev/ftb/mods/ftbteambases/data/construction/workers/AbstractStructureWorker.java
@@ -77,8 +77,10 @@ public abstract class AbstractStructureWorker implements ConstructionWorker {
     protected final BlockPos getPlacementOrigin(ServerLevel level, XZ xz, Optional<Integer> yPos) {
         int x = xz.x();
         int z = xz.z();
-        return yPos
-                .map(y -> new BlockPos(x, y, z))
-                .orElse(new BlockPos(x, level.getHeight(Heightmap.Types.WORLD_SURFACE, x, z), z));
+        if (yPos.isPresent()) {
+            return new BlockPos(x, yPos.get(), z);
+        }
+        level.getChunk(x >> 4, z >> 4);
+        return new BlockPos(x, level.getHeight(Heightmap.Types.WORLD_SURFACE, x, z), z);
     }
 }


### PR DESCRIPTION
Makes sure the chunk data is available when calculating the world surface height, preventing incorrect Y-level placement due to unloaded chunks.